### PR TITLE
feat: Implement disk space reporting feature during directory cleanup

### DIFF
--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -64,7 +64,3 @@ var updateLocalConfig = &cobra.Command{
 		updateValuesInLocalConfig()
 	},
 }
-
-func init() {
-	cleanDependencies.Flags().BoolVarP(&showSpaceFreed, "show-space", "s", false, "Show amount of disk space freed")
-}

--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -64,3 +64,7 @@ var updateLocalConfig = &cobra.Command{
 		updateValuesInLocalConfig()
 	},
 }
+
+func init() {
+	cleanDependencies.Flags().BoolVarP(&showSpaceFreed, "show-space", "s", false, "Show amount of disk space freed")
+}

--- a/cmd/helper.go
+++ b/cmd/helper.go
@@ -243,3 +243,30 @@ func GenerateProgressBar(barPercentage int, message string) *progressbar.Progres
 
 	return bar
 }
+
+func getDirSize(path string) (int64, error) {
+	var size int64
+	err := filepath.Walk(path, func(_ string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			size += info.Size()
+		}
+		return nil
+	})
+	return size, err
+}
+
+func formatBytes(bytes int64) string {
+	const unit = 1024
+	if bytes < unit {
+		return fmt.Sprintf("%d B", bytes)
+	}
+	div, exp := int64(unit), 0
+	for n := bytes / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(bytes)/float64(div), "KMGTPE"[exp])
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -49,10 +49,8 @@ func cleanupDir(dir string) {
 			continue
 		}
 
-		if showSpaceFreed {
-			if size, err := getDirSize(fileSystemPath); err == nil {
-				totalFreedSpace += size
-			}
+		if size, err := getDirSize(fileSystemPath); err == nil {
+			totalFreedSpace += size
 		}
 
 		os.RemoveAll(fileSystemPath)
@@ -76,9 +74,7 @@ func cleanDir(dir string) {
 		bar.Add(1)
 	}
 
-	if showSpaceFreed {
-		fmt.Printf("\nTotal space freed: %s\n", formatBytes(totalFreedSpace))
-	}
+	fmt.Printf("\nTotal space freed: %s\n", formatBytes(totalFreedSpace))
 }
 
 func updateLocalConfigurationWithRemoteConfig() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -49,14 +49,20 @@ func cleanupDir(dir string) {
 			continue
 		}
 
+		if showSpaceFreed {
+			if size, err := getDirSize(fileSystemPath); err == nil {
+				totalFreedSpace += size
+			}
+		}
+
 		os.RemoveAll(fileSystemPath)
 	}
-
 }
 
 func cleanDir(dir string) {
-	dirsToClean := findAllChildDirs(dir)
+	totalFreedSpace = 0
 
+	dirsToClean := findAllChildDirs(dir)
 	dirsToCleanCount := len(dirsToClean)
 
 	if dirsToCleanCount <= 0 {
@@ -67,7 +73,11 @@ func cleanDir(dir string) {
 	for i := 0; i < dirsToCleanCount; i++ {
 		dir := dirsToClean[i]
 		cleanupDir(dir)
-		bar.Add(i + 1)
+		bar.Add(1)
+	}
+
+	if showSpaceFreed {
+		fmt.Printf("\nTotal space freed: %s\n", formatBytes(totalFreedSpace))
 	}
 }
 

--- a/cmd/vars.go
+++ b/cmd/vars.go
@@ -15,3 +15,6 @@ var config Config
 
 var enumValue string
 var allowedValuesInLocalUpdate = []string{"add", "remove", "update"}
+
+var totalFreedSpace int64
+var showSpaceFreed bool = false

--- a/cmd/vars.go
+++ b/cmd/vars.go
@@ -17,4 +17,3 @@ var enumValue string
 var allowedValuesInLocalUpdate = []string{"add", "remove", "update"}
 
 var totalFreedSpace int64
-var showSpaceFreed bool = false


### PR DESCRIPTION
- Introduced helper functions to calculate directory size and format byte values.
- Updated the cleanup logic to report total space freed after cleaning directories.

refer to https://github.com/bhumit070/deps-cleaner/issues/2