### PR TITLE
fix: reload shell profile using exec for better compatibility

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -42,7 +42,12 @@ fi
 
 echo $command >>"$HOME/$shellFile"
 
-echo "Reloading shell profile..."
-exec "$SHELL" -l
+echo "Changes applied. Reload shell now? [y/N]"
+read -r answer
+if [[ "$answer" =~ ^[Yy]$ ]]; then
+	exec "$SHELL" -l
+else
+	echo "You can reload the shell later by running: exec \"\$SHELL\" -l"
+fi
 
 echo "installation completed."

--- a/install.sh
+++ b/install.sh
@@ -43,6 +43,6 @@ fi
 echo $command >>"$HOME/$shellFile"
 
 echo "Reloading shell profile..."
-source "$HOME/$shellFile" &>/dev/null
+exec "$SHELL" -l
 
 echo "installation completed."


### PR DESCRIPTION
### Key Change
```bash
source "$HOME/$shellFile" &>/dev/null
```
was replaced with:
```bash
exec "$SHELL" -l
```

### Why This Works
- **`source` Limitation**: When a script sources a file, the changes apply only to the current subshell and not to the parent shell.
- **`exec "$SHELL" -l`**: Replaces the current shell process with a new login shell (`-l`), which reads the updated shell profile (`.bashrc` or `.zshrc`). This ensures the new `$PATH` and other environment changes take effect immediately.

### Improved Flow
1. After appending the export command to the shell configuration file (`$HOME/.bashrc` or `$HOME/.zshrc`):
2. The script uses `exec "$SHELL" -l` to replace the current shell with a new login shell.
